### PR TITLE
Indicate required dependencies explicitly in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,8 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": ">=1.17"
+    "minecraft": ">=1.17",
+    "cardinal-components": "*"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
For those who didn't read the installation manual carefully (like me)